### PR TITLE
Cover case where two focus traps are transitioned between pages

### DIFF
--- a/src/FocalPoint.jsx
+++ b/src/FocalPoint.jsx
@@ -29,6 +29,15 @@ let FocalPoint = React.createClass({
     timer = setTimeout(_ => stack[stack.length - 1].focus(), 10)
   },
 
+  returnFocus() {
+    // When transitioning between pages using hash route state,
+    // this anchor is some times lost. Do not attempt to focus
+    // on a non-existent anchor.
+    if (this.state.anchor != null && 'focus' in this.state.anchor) {
+      this.state.anchor.focus()
+    }
+  },
+
   componentDidMount() {
     stack.push(this)
 
@@ -44,7 +53,8 @@ let FocalPoint = React.createClass({
     document.removeEventListener('focus', this._onBlur, true)
 
     clearTimeout(timer)
-    this.state.anchor.focus()
+
+    this.returnFocus()
   },
 
   render() {

--- a/src/FocalPoint.jsx
+++ b/src/FocalPoint.jsx
@@ -30,11 +30,13 @@ let FocalPoint = React.createClass({
   },
 
   returnFocus() {
+    let { anchor } = this.state
+
     // When transitioning between pages using hash route state,
     // this anchor is some times lost. Do not attempt to focus
     // on a non-existent anchor.
-    if (this.state.anchor != null && 'focus' in this.state.anchor) {
-      this.state.anchor.focus()
+    if (anchor === 'object' && 'focus' in anchor) {
+      anchor.focus()
     }
   },
 

--- a/src/__tests__/FocusTrap.test.jsx
+++ b/src/__tests__/FocusTrap.test.jsx
@@ -90,7 +90,7 @@ describe('FocusTrap', function() {
 
     let component = render(<Component />)
 
-    component.refs.focus.setState({ anchor: false })
+    component.refs.focus.setState({ anchor: null })
     component.setState({ active: false })
   })
 

--- a/src/__tests__/FocusTrap.test.jsx
+++ b/src/__tests__/FocusTrap.test.jsx
@@ -77,4 +77,21 @@ describe('FocusTrap', function() {
       done()
     }, 50)
   })
+
+  it ('does not focus a null anchor when unmounting', function() {
+    let Component = React.createClass({
+      getInitialState() {
+        return { active: true }
+      },
+      render() {
+        return this.state.active ? (<FocusTrap ref="focus"/>) : null
+      }
+    })
+
+    let component = render(<Component />)
+
+    component.refs.focus.setState({ anchor: false })
+    component.setState({ active: false })
+  })
+
 })


### PR DESCRIPTION
Hit an issue transitioning between two pages with focus traps in IE10 using hash location history. For some reason, focus is lost when the hash url changes (I _think_. It's kind of a mess to debug)

The real moral of the story is: don't use window#hash for URLs, but in any case this PR fixes the problem.

<img width="1188" alt="screen shot 2015-09-30 at 6 59 05 pm" src="https://cloud.githubusercontent.com/assets/590904/10209121/61a480e8-67a6-11e5-8b48-e57a63f5640e.png">
