### PR TITLE
Update dependencies, remove role attribute, update return focus

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
-  "stage": 2,
-  "loose": true,
+  "presets": [
+    "es2015",
+    "react",
+    "stage-2"
+  ],
   "sourceMaps": "inline"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "globals": {
+    "Promise": true
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    }
+  },
+  "rules": {
+    "semi": 0
+  },
+  "plugins": [
+    "react"
+  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "rules": {
+    "react/prop-types" : 0,
+    "no-console": 0,
+    "no-unused-vars" : ["error", { "args": "none" }]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0
+
+- Removed "role" attribute from container. Otherwise, screen readers will read this as "Navigation. One item", since there's only one immediate readable child.
+
 ## 2.2.0
 
 - Added looser `react` peer dependency declaration

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ example:
 clean:
 	rm -rf dist
 
-test:
-	NODE_ENV=test karma start --single-run
+lint:
+	@ eslint {src,test}/**/*.{js,jsx}
 
-test-watch:
-	NODE_ENV=test karma start
+test: lint
+	NODE_ENV=test karma start --single-run

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+general:
+  branches:
+    ignore:
+      - gh-pages
+machine:
+  node:
+    version: 6.3.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,8 @@ module.exports = function (config) {
     },
 
     webpack: {
-      resolve : webpackConfig.resolve
+      resolve : webpackConfig.resolve,
+      module  : webpackConfig.module
     },
 
     webpackServer: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 var webpackConfig = require('./webpack.config')
 
-module.exports = function(config) {
+module.exports = function (config) {
 
   config.set({
 
@@ -12,22 +12,14 @@ module.exports = function(config) {
       'test/*.js*'
     ],
 
-    reporters: [ 'progress', 'coverage' ],
+    reporters: [ 'progress' ],
 
     preprocessors: {
       'test/*.js*': [ 'webpack' ]
     },
 
     webpack: {
-      resolve : webpackConfig.resolve,
-      module  : {
-        loaders: webpackConfig.module.loaders,
-        postLoaders: [{
-          test: /\.jsx*$/,
-          exclude: /(test|node_modules)\//,
-          loader: 'istanbul-instrumenter'
-        }]
-      }
+      resolve : webpackConfig.resolve
     },
 
     webpackServer: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "src/focus-trap.js",
   "scripts": {
     "start": "make example",
-    "test": "make test",
+    "lint": "eslint {src,test}/**/*.{js,jsx}",
+    "test": "npm run lint && make test",
     "prepublish": "make build"
   },
   "repository": {
@@ -20,24 +21,24 @@
   "author": "Nate Hunzaker",
   "license": "MIT",
   "devDependencies": {
-    "babel": "~5",
-    "babel-core": "~5",
-    "babel-loader": "~5",
+    "babel-core": "6.10.4",
+    "babel-loader": "6.2.4",
+    "babel-preset-es2015": "6.9.0",
+    "babel-preset-react": "6.11.1",
+    "babel-preset-stage-2": "6.11.0",
+    "eslint": "3.1.1",
+    "eslint-plugin-react": "5.2.2",
     "istanbul": "~0.4",
     "istanbul-instrumenter-loader": "~0.1",
-    "karma": "~> 0.13.8",
-    "karma-chrome-launcher": "~0.2",
-    "karma-cli": "~0.1",
-    "karma-coverage": "~0.5",
-    "karma-mocha": "~0.2",
+    "karma": "1.1.1",
+    "karma-chrome-launcher": "1.0.1",
+    "karma-coverage": "1.1.0",
+    "karma-mocha": "1.1.1",
     "karma-webpack": "~1",
-    "mocha": "~2",
+    "mocha": "2.5.3",
     "react": "~15.0.0",
     "react-addons-test-utils": "~15.0.0",
     "react-dom": "~15.0.0",
-    "webpack": "~1"
-  },
-  "peerDependencies": {
-    "react": ">= 0.14.0"
+    "webpack": "~1.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "main": "src/focus-trap.js",
   "scripts": {
     "start": "make example",
-    "lint": "eslint {src,test}/**/*.{js,jsx}",
-    "test": "npm run lint && make test",
+    "test": "make test",
     "prepublish": "make build"
   },
   "repository": {
@@ -28,11 +27,8 @@
     "babel-preset-stage-2": "6.11.0",
     "eslint": "3.1.1",
     "eslint-plugin-react": "5.2.2",
-    "istanbul": "~0.4",
-    "istanbul-instrumenter-loader": "~0.1",
     "karma": "1.1.1",
     "karma-chrome-launcher": "1.0.1",
-    "karma-coverage": "1.1.0",
     "karma-mocha": "1.1.1",
     "karma-webpack": "~1",
     "mocha": "2.5.3",

--- a/src/focal-point.jsx
+++ b/src/focal-point.jsx
@@ -19,8 +19,7 @@ let FocalPoint = React.createClass({
 
   getDefaultProps() {
     return {
-      element   : 'div',
-      tabIndex  : '0'
+      element : 'div'
     }
   },
 
@@ -33,25 +32,15 @@ let FocalPoint = React.createClass({
   },
 
   trapFocus(e) {
+    let el = stack[stack.length - 1]
+
     clearTimeout(timer)
-    timer = setTimeout(_ => stack[stack.length - 1].focus(), 10)
-  },
-
-  returnFocus() {
-    let { anchor } = this.state
-
-    // When transitioning between pages using hash route state,
-    // this anchor is some times lost. Do not attempt to focus
-    // on a non-existent anchor.
-    if (anchor && typeof anchor === 'object' && typeof anchor.focus === 'function') {
-      anchor.focus()
-    }
+    timer = setTimeout(el.focus, 0)
   },
 
   componentDidMount() {
     stack.push(this)
 
-    this.setState({ anchor: document.activeElement })
     this.trapFocus()
 
     document.addEventListener('focus', this._onBlur, true)
@@ -62,16 +51,14 @@ let FocalPoint = React.createClass({
 
     document.removeEventListener('focus', this._onBlur, true)
 
-    clearTimeout(timer)
-
-    this.returnFocus()
+    this.trapFocus()
   },
 
   render() {
-    let { children, element:Element, ...safe } = this.props
+    let { children, element:Element, className } = this.props
 
     return (
-      <Element ref="root" { ...safe }>
+      <Element ref="root" tabIndex="0" className={ className }>
         { children }
       </Element>
     )

--- a/src/focus-trap.jsx
+++ b/src/focus-trap.jsx
@@ -11,18 +11,17 @@ let FocusTrap = React.createClass({
   getDefaultProps() {
     return {
       active    : true,
-      className : 'focus-trap',
-      role      : 'dialog'
+      className : 'focus-trap'
     }
   },
 
   render() {
-    let { active, className, children, element, onExit, role } = this.props
+    let { active, className, children, element, onExit } = this.props
 
     if (!active ) return null
 
     return (
-      <div className={ `${ className }-wrapper` } onKeyUp={ this._onKeyUp } role={ role }>
+      <div className={ `${ className }-wrapper` } onKeyUp={ this._onKeyUp }>
         <div aria-hidden="true" className={ `${ className }-backdrop` } onClick={ onExit } />
         <FocalPoint ref='focus' className={ className } element={ element }>
           { children }

--- a/test/focus-trap.test.jsx
+++ b/test/focus-trap.test.jsx
@@ -79,27 +79,4 @@ describe('FocusTrap', function() {
     }, 50)
   })
 
-  it ('does not focus a null anchor when unmounting', function() {
-    let Component = React.createClass({
-      getInitialState() {
-        return { active: true }
-      },
-      render() {
-        return this.state.active ? (<FocusTrap ref="focus"/>) : null
-      }
-    })
-
-    let component = render(<Component />)
-
-    component.refs.focus.setState({ anchor: null })
-    component.setState({ active: false })
-  })
-
-  it ('handles null anchor points', function() {
-    let component = render(<FocusTrap />)
-    let trap = component.refs.focus
-
-    trap.setState({ anchor: null })
-    component.refs.focus.returnFocus()
-  })
 })

--- a/test/focus-trap.test.jsx
+++ b/test/focus-trap.test.jsx
@@ -10,7 +10,7 @@ describe('FocusTrap', function() {
 
   it ('does not render when not active', function() {
     let component = render(<FocusTrap active={ false } />)
-      assert.equal(DOM.findDOMNode(component), null)
+    assert.equal(DOM.findDOMNode(component), null)
   })
 
   describe('when a key is pressed', function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,7 @@ module.exports = {
   },
 
   resolve: {
-    extensions: ['', '.js', '.jsx'],
-    modulesDirectories: [ 'web_modules', 'node_modules', 'src', 'lib', __dirname ]
+    extensions: ['', '.js', '.jsx']
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     loaders: [{
       test    : /\.jsx*$/,
       exclude : /node_modules/,
-      loader  : 'babel-loader'
+      loader  : 'babel'
     }]
   }
 }


### PR DESCRIPTION
This PR updates dependencies, adds ESLint, and refactors the way that returning focus works in a way that prevents double rendering.

fixes #14 

/cc @greypants 
