### PR TITLE
Eliminate stack to avoid memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 2.6.0
+
+- Eliminate internal focus stack, avoiding a memory leak
+
 # 2.5.0
 
 - Modernization. Ensure support for React 16.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-focus-trap",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0-beta.0",
   "description": "Traps focus for accessible dropdowns and modal content.",
   "main": "src/focus-trap.js",
   "scripts": {

--- a/src/focus-trap.js
+++ b/src/focus-trap.js
@@ -3,15 +3,14 @@ import FocalPoint from './focal-point'
 
 const defaultProps = {
   active: true,
-  className: 'focus-trap'
+  className: 'focus-trap',
+  onExit: () => {}
 }
 
 class FocusTrap extends React.Component {
   constructor(props, context) {
     super(props, context)
-
     this._onKeyUp = this._onKeyUp.bind(this)
-    this._setFocus = this._setFocus.bind(this)
   }
 
   render() {
@@ -26,7 +25,7 @@ class FocusTrap extends React.Component {
           className={`${className}-backdrop`}
           onClick={onExit}
         />
-        <FocalPoint ref={this._setFocus} className={className} element={element}>
+        <FocalPoint className={className} element={element}>
           {children}
         </FocalPoint>
       </div>
@@ -35,12 +34,8 @@ class FocusTrap extends React.Component {
 
   // Private -------------------------------------------------- //
 
-  _setFocus(el) {
-    this.focus = el
-  }
-
   _onKeyUp(event) {
-    if (event.key === 'Escape' && 'onExit' in this.props) {
+    if (event.key === 'Escape') {
       this.props.onExit()
     }
   }

--- a/test/focus-trap.test.js
+++ b/test/focus-trap.test.js
@@ -64,7 +64,10 @@ describe('FocusTrap', function() {
   })
 
   it('returns focus when it is lost', function(done) {
-    let component = DOM.render(<FocusTrap />, document.body)
+    let component = DOM.render(
+      <FocusTrap className="focus-trap" />,
+      document.body
+    )
     let el = DOM.findDOMNode(component).querySelector('.focus-trap')
 
     document.body.dispatchEvent(new Event('blur'))

--- a/test/focus-trap.test.js
+++ b/test/focus-trap.test.js
@@ -65,12 +65,9 @@ describe('FocusTrap', function() {
 
   it('returns focus when it is lost', function(done) {
     let component = DOM.render(<FocusTrap />, document.body)
-    let el = DOM.findDOMNode(component.focus)
+    let el = DOM.findDOMNode(component).querySelector('.focus-trap')
 
-    component.focus._onBlur({
-      preventDefault: stub,
-      target: document.body
-    })
+    document.body.dispatchEvent(new Event('blur'))
 
     setTimeout(function() {
       assert.equal(document.activeElement, el)


### PR DESCRIPTION
This commit eliminates the stack of focused elements. Since React
operates on a tree, we get a stack for free as a by-product.

This prevents a case where the first active element is never removed
from the stack, causing a memory leak.

I've also done some small changes to the focus trap component to avoid
some extra work only required for testing.

---

This is an effort to address #22