### PR TITLE
Fix `main` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "2.7.1",
   "description": "Traps focus for accessible dropdowns and modal content.",
-  "main": "src/focus-trap.js",
+  "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server",
     "build:example": "webpack -p",


### PR DESCRIPTION
Node.js 16 prints a warning:

> [DEP0128] DeprecationWarning: Invalid 'main' field in 'node_modules/react-focus-trap/package.json' of 'src/focus-trap.js'. Please either fix that or report it to the module author

This is because `src/focus-trap.js` is not published to npm, so I changed it to `index.js` instead:
https://unpkg.com/browse/react-focus-trap@2.7.1/